### PR TITLE
Remove jQuery

### DIFF
--- a/view.js
+++ b/view.js
@@ -15,18 +15,19 @@ function loadScripts(srcs, callback={}){
 	script.onload = () => {loadScripts(srcs, callback)};
 }
 
+// Load Leaflet style
 let style = document.createElement('link');
 style.rel = "stylesheet";
 style.href = "https://unpkg.com/leaflet@1.7.1/dist/leaflet.css";
 document.getElementsByTagName('head')[0].appendChild(style);
 
-// load jQuery, leaflet
-loadScripts(["https://code.jquery.com/jquery-3.6.0.min.js","https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"], () => {
+// load scripts: Leaflet
+loadScripts(["https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"], () => {
 	// create Map viewer
-	jQuery('<div/>', {
-		id: 'mapid',
-		style: 'width: 100%; height: 100%; position: relative; left: 0; top: 105%; z-index: 100000;'
-	}).appendTo( $( ".c-inline-map__container" ) );
+	let mapelem = document.createElement('div');
+	mapelem.id = 'mapid';
+	mapelem.style = 'width: 100%; height: 100%; position: relative; left: 0; top: 105%; z-index: 100000;';
+	document.getElementsByClassName("c-inline-map__container")[0].appendChild(mapelem);
 
 	let map = L.map('mapid').setView([48, 0], 5);
 	L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', {
@@ -37,19 +38,17 @@ loadScripts(["https://code.jquery.com/jquery-3.6.0.min.js","https://unpkg.com/le
 	regions.forEach(async (id) => {
 		if (id == 9999) {return}
 		// load region boundary and add as polygon
-		jQuery.ajax({
-			data: {'region': id},
-			headers: {'onlyprops': 'true'},
-			success: (json) => {
-				json.regions[0].geometry.forEach((p) => {
+		fetch("https://www.komoot.com/product/regions?region="+id, {headers: {'onlyprops': 'true'}})
+			.then(res => res.json())
+			.then(json => {
+				json.regions[0].geometry.forEach(p => {
 					let region = [];
 					p.forEach((i) => {
 						region.push([i.lat, i.lng]);
 					});
 					L.polygon(region).addTo(map);
 				});
-			}
-		});
+			});
 	});
 });
 

--- a/view.js
+++ b/view.js
@@ -4,54 +4,54 @@ var regions = kmtBoot.getProps().packages.models.map((p) => {
 	return p.attributes.region.id
 });
 
-// load jQuery
-var script = document.createElement('script');
-script.src = "https://code.jquery.com/jquery-3.6.0.min.js";
-document.getElementsByTagName('head')[0].appendChild(script);
-
-// wait for jQuery to load
-script.onload = () => {
-	// load leaflet
-	var script = document.createElement('script');
-	script.src = "https://unpkg.com/leaflet@1.7.1/dist/leaflet.js";
+function loadScripts(srcs, callback={}){
+	if(srcs.length == 0){
+		callback();
+		return;
+	}
+	let script = document.createElement('script');
+	script.src = srcs.shift();
 	document.getElementsByTagName('head')[0].appendChild(script);
-	var style = document.createElement('link');
-	style.rel = "stylesheet";
-	style.href = "https://unpkg.com/leaflet@1.7.1/dist/leaflet.css";
-	document.getElementsByTagName('head')[0].appendChild(style);
+	script.onload = () => {loadScripts(srcs, callback)};
+}
 
-	// wait for leaflet to load
-	script.onload = () => {
-		// create Map viewer
-		jQuery('<div/>', {
-			id: 'mapid',
-			style: 'width: 100%; height: 100%; position: relative; left: 0; top: 105%; z-index: 100000;'
-                }).appendTo( $( ".c-inline-map__container" ) );
+let style = document.createElement('link');
+style.rel = "stylesheet";
+style.href = "https://unpkg.com/leaflet@1.7.1/dist/leaflet.css";
+document.getElementsByTagName('head')[0].appendChild(style);
 
-		var map = L.map('mapid').setView([48, 0], 5);
-		L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-			attribution: 'Map data &copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
-		}).addTo(map);
+// load jQuery, leaflet
+loadScripts(["https://code.jquery.com/jquery-3.6.0.min.js","https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"], () => {
+	// create Map viewer
+	jQuery('<div/>', {
+		id: 'mapid',
+		style: 'width: 100%; height: 100%; position: relative; left: 0; top: 105%; z-index: 100000;'
+	}).appendTo( $( ".c-inline-map__container" ) );
 
-		// iterate over unlocked regions and draw the result
-		regions.forEach(async (id) => {
-			if (id == 9999) {return}
-			// load region boundary and add as polygon
-			jQuery.ajax({
-				data: {'region': id},
-				headers: {'onlyprops': 'true'},
-				success: (json) => {
-					json.regions[0].geometry.forEach((p) => {
-						var region = [];
-						p.forEach((i) => {
-							region.push([i.lat, i.lng]);
-						});
-						L.polygon(region).addTo(map);
+	let map = L.map('mapid').setView([48, 0], 5);
+	L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+		attribution: 'Map data &copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+	}).addTo(map);
+
+	// iterate over unlocked regions and draw the result
+	regions.forEach(async (id) => {
+		if (id == 9999) {return}
+		// load region boundary and add as polygon
+		jQuery.ajax({
+			data: {'region': id},
+			headers: {'onlyprops': 'true'},
+			success: (json) => {
+				json.regions[0].geometry.forEach((p) => {
+					let region = [];
+					p.forEach((i) => {
+						region.push([i.lat, i.lng]);
 					});
-				}
-			});
+					L.polygon(region).addTo(map);
+				});
+			}
 		});
-	};
-};
+	});
+});
+
 
 console.log("You have %d free region(s) available!", kmtBoot.getProps().freeProducts.length);

--- a/view.js
+++ b/view.js
@@ -38,7 +38,7 @@ loadScripts(["https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"], () => {
 	regions.forEach(async (id) => {
 		if (id == 9999) {return}
 		// load region boundary and add as polygon
-		fetch("https://www.komoot.com/product/regions?region="+id, {headers: {'onlyprops': 'true'}})
+		fetch("?region="+id, {headers: {'onlyprops': 'true'}})
 			.then(res => res.json())
 			.then(json => {
 				json.regions[0].geometry.forEach(p => {


### PR DESCRIPTION
jQuery is not necessary, we can use simple vanilla JS instead.
Also added a recursive `loadScripts()` function to improve overall readability.
(Tested only in LibreWolf)